### PR TITLE
Improve CommandParser code quality

### DIFF
--- a/src/main/java/mittens/commands/Command.java
+++ b/src/main/java/mittens/commands/Command.java
@@ -1,5 +1,8 @@
 package mittens.commands;
 
+import java.util.Map;
+
+import mittens.parser.RawCommandElements;
 import mittens.storage.Storage;
 import mittens.task.TaskList;
 import mittens.ui.Ui;
@@ -8,13 +11,9 @@ import mittens.ui.Ui;
  * Represents a command that is obtained by parsing the user input.
  */
 public abstract class Command {
-    
-    /** Whether the program should exit upon execution */
-    protected boolean isExit;
 
-    public Command() {
-        this.isExit = false;
-    }
+    /** Whether the program should exit upon execution */
+    protected boolean isExit = false;
 
     /**
      * Executes the command by interacting with the task list, UI, and storage.

--- a/src/main/java/mittens/commands/DeleteCommand.java
+++ b/src/main/java/mittens/commands/DeleteCommand.java
@@ -1,16 +1,22 @@
 package mittens.commands;
 
+import java.time.LocalDate;
+
 import mittens.MittensException;
+import mittens.parser.BadInputException;
+import mittens.parser.RawCommandElements;
 import mittens.storage.Storage;
+import mittens.task.Deadline;
+import mittens.task.Event;
 import mittens.task.Task;
 import mittens.task.TaskList;
+import mittens.task.Todo;
 import mittens.ui.Ui;
 
 /**
  * Represents a command for deleting a task from the task list.
  */
 public class DeleteCommand extends Command {
-    
     protected int index;
 
     /**
@@ -21,6 +27,18 @@ public class DeleteCommand extends Command {
     public DeleteCommand(int index) {
         super();
         this.index = index;
+    }
+
+    /**
+     * Creates a new DeleteCommand object with the specified command elements.
+     * It assumes the command name corresponds with this class.
+     *
+     * @param elements The RawCommandElements object
+     * @throws BadInputException If the input is invalid
+     */
+    public DeleteCommand(RawCommandElements elements) throws BadInputException {
+        assert elements.getCommand().equals("delete") : "Command name should be matching";
+        this.index = elements.getArgumentAsIntegerOrThrow();
     }
 
     @Override

--- a/src/main/java/mittens/commands/ExitCommand.java
+++ b/src/main/java/mittens/commands/ExitCommand.java
@@ -1,6 +1,8 @@
 package mittens.commands;
 
 import mittens.MittensException;
+import mittens.parser.BadInputException;
+import mittens.parser.RawCommandElements;
 import mittens.storage.Storage;
 import mittens.task.TaskList;
 import mittens.ui.Ui;
@@ -15,6 +17,17 @@ public class ExitCommand extends Command {
      */
     public ExitCommand() {
         super();
+        this.isExit = true;
+    }
+
+    /**
+     * Creates a new ExitCommand object with the specified command elements.
+     * It assumes the command name corresponds with this class.
+     *
+     * @param elements The RawCommandElements object
+     */
+    public ExitCommand(RawCommandElements elements) {
+        assert elements.getCommand().equals("exit") : "Command name should be matching";
         this.isExit = true;
     }
 

--- a/src/main/java/mittens/commands/FindCommand.java
+++ b/src/main/java/mittens/commands/FindCommand.java
@@ -3,6 +3,8 @@ package mittens.commands;
 import java.util.ArrayList;
 import java.util.List;
 
+import mittens.parser.BadInputException;
+import mittens.parser.RawCommandElements;
 import mittens.storage.Storage;
 import mittens.task.Task;
 import mittens.task.TaskList;
@@ -17,6 +19,18 @@ public class FindCommand extends Command {
     public FindCommand(String keyword) {
         super();
         this.keyword = keyword;
+    }
+
+    /**
+     * Creates a new FindCommand object with the specified command elements.
+     * It assumes the command name corresponds with this class.
+     *
+     * @param elements The RawCommandElements object
+     * @throws BadInputException If the input is invalid
+     */
+    public FindCommand(RawCommandElements elements) throws BadInputException {
+        assert elements.getCommand().equals("find") : "Command name should be matching";
+        this.keyword = elements.getArgumentOrThrow();
     }
 
     @Override

--- a/src/main/java/mittens/commands/ListCommand.java
+++ b/src/main/java/mittens/commands/ListCommand.java
@@ -1,5 +1,6 @@
 package mittens.commands;
 
+import mittens.parser.RawCommandElements;
 import mittens.storage.Storage;
 import mittens.task.Task;
 import mittens.task.TaskList;
@@ -12,7 +13,16 @@ import java.util.List;
  * Represents a command for listing all tasks in the task list.
  */
 public class ListCommand extends Command {
-    
+    /**
+     * Creates a new ListCommand object with the specified command elements.
+     * It assumes the command name corresponds with this class.
+     *
+     * @param elements The RawCommandElements object
+     */
+    public ListCommand(RawCommandElements elements) {
+        assert elements.getCommand().equals("list") : "Command name should be matching";
+    }
+
     @Override
     public void execute(TaskList tasks, Ui ui, Storage storage) {
         List<String> messages = new ArrayList<>();

--- a/src/main/java/mittens/commands/MarkCommand.java
+++ b/src/main/java/mittens/commands/MarkCommand.java
@@ -1,6 +1,8 @@
 package mittens.commands;
 
 import mittens.MittensException;
+import mittens.parser.BadInputException;
+import mittens.parser.RawCommandElements;
 import mittens.storage.Storage;
 import mittens.task.Task;
 import mittens.task.TaskList;
@@ -21,6 +23,18 @@ public class MarkCommand extends Command {
     public MarkCommand(int index) {
         super();
         this.index = index;
+    }
+
+    /**
+     * Creates a new MarkCommand object with the specified command elements.
+     * It assumes the command name corresponds with this class.
+     *
+     * @param elements The RawCommandElements object
+     * @throws BadInputException If the input is invalid
+     */
+    public MarkCommand(RawCommandElements elements) throws BadInputException {
+        assert elements.getCommand().equals("mark") : "Command name should be matching";
+        this.index = elements.getArgumentAsIntegerOrThrow();
     }
 
     @Override

--- a/src/main/java/mittens/commands/UnmarkCommand.java
+++ b/src/main/java/mittens/commands/UnmarkCommand.java
@@ -1,6 +1,8 @@
 package mittens.commands;
 
 import mittens.MittensException;
+import mittens.parser.BadInputException;
+import mittens.parser.RawCommandElements;
 import mittens.storage.Storage;
 import mittens.task.Task;
 import mittens.task.TaskList;
@@ -21,6 +23,18 @@ public class UnmarkCommand extends Command {
     public UnmarkCommand(int index) {
         super();
         this.index = index;
+    }
+
+    /**
+     * Creates a new UnmarkCommand object with the specified command elements.
+     * It assumes the command name corresponds with this class.
+     *
+     * @param elements The RawCommandElements object
+     * @throws BadInputException If the input is invalid
+     */
+    public UnmarkCommand(RawCommandElements elements) throws BadInputException {
+        assert elements.getCommand().equals("unmark") : "Command name should be matching";
+        this.index = elements.getArgumentAsIntegerOrThrow();
     }
 
     @Override

--- a/src/main/java/mittens/parser/CommandParser.java
+++ b/src/main/java/mittens/parser/CommandParser.java
@@ -29,117 +29,17 @@ public class CommandParser {
      * @throws BadInputException If the input does not match any known command format
      */
     public Command parse(String input) throws BadInputException {
-        if (input.equals("bye")) {
-            return new ExitCommand();
-        } else if (input.equals("list")) {
-            return new ListCommand();
-        } else if (input.startsWith("mark")) {
-            try {
-                int index = Integer.parseInt(input.split(" ")[1]);
-                return new MarkCommand(index);
-            } catch (NumberFormatException e) {
-                throw new BadInputException("Argument for command 'mark' must be a number");
-            }
-        } else if (input.startsWith("unmark")) {
-            try {
-                int index = Integer.parseInt(input.split(" ")[1]);
-                return new UnmarkCommand(index);
-            } catch (NumberFormatException e) {
-                throw new BadInputException("Argument for command 'mark' must be a number");
-            }
-        } else if (input.startsWith("delete")) {
-            try {
-                int index = Integer.parseInt(input.split(" ")[1]);
-                return new DeleteCommand(index);
-            } catch (NumberFormatException e) {
-                throw new BadInputException("Argument for command 'delete' must be a number");
-            }
-        } else if (input.startsWith("find")) {
-            String keyword = input.substring(5);
+        RawCommandElements elements = new RawCommandElements(input);
 
-            return new FindCommand(keyword);
-        } else if (input.startsWith("todo")) {
-            String description = input.substring(5);
-
-            Todo newTodo = new Todo(description);
-            return new AddCommand(newTodo);
-        } else if (input.startsWith("deadline")) {
-            // Separate the inputs so that the first element contains the description while
-            // the rest contains flags.
-            String[] inputs = input.split(" /");
-            String description = inputs[0].substring(9);
-
-            LocalDate by = null;
-            for (int i = 1; i < inputs.length; i++) {
-                String[] flagWords = inputs[i].split(" ");
-                if (flagWords[0].equals("by")) {
-                    if (by == null) {
-                        try {
-                            by = LocalDate.parse(inputs[i].substring(3));
-                        } catch (DateTimeParseException e) {
-                            throw new BadInputException("Invalid date format for 'by' flag");
-                        }
-                    } else {
-                        throw new BadInputException("Found duplicate of 'by' flag");
-                    }
-                } else {
-                    throw new BadInputException("'%s' is not a known flag".formatted(flagWords[0]));
-                }
-            }
-
-            if (by == null) {
-                throw new BadInputException("Command 'deadline' must have a 'by' flag");
-            }
-
-            Deadline newDeadline = new Deadline(description, by);
-            return new AddCommand(newDeadline);
-        } else if (input.startsWith("event")) {
-            // Separate the inputs so that the first element contains the description while
-            // the rest contains flags.
-            String[] inputs = input.split(" /");
-            String description = inputs[0].substring(6);
-
-            LocalDate from = null;
-            LocalDate to = null;
-            for (int i = 1; i < inputs.length; i++) {
-                String[] flagWords = inputs[i].split(" ");
-                if (flagWords[0].equals("from")) {
-                    if (from == null) {
-                        try {
-                            from = LocalDate.parse(inputs[i].substring(5));
-                        } catch (DateTimeParseException e) {
-                            throw new BadInputException("Invalid date format for 'from' flag");
-                        }
-                    } else {
-                        throw new BadInputException("Found duplicate of 'from' flag");
-                    }
-                } else if (flagWords[0].equals("to")) {
-                    if (to == null) {
-                        try {
-                            to = LocalDate.parse(inputs[i].substring(3));
-                        } catch (DateTimeParseException e) {
-                            throw new BadInputException("Invalid date format for 'to' flag");
-                        }
-                    } else {
-                        throw new BadInputException("Found duplicate of 'to' flag");
-                    }
-                } else {
-                    throw new BadInputException("'%s' is not a known flag".formatted(flagWords[0]));
-                }
-            }
-
-            if (from == null) {
-                throw new BadInputException("Command 'event' must have a 'from' flag");
-            }
-
-            if (to == null) {
-                throw new BadInputException("Command 'event' must have a 'to' flag");
-            }
-
-            Event newEvent = new Event(description, from, to);
-            return new AddCommand(newEvent);
-        } else {
-            throw new BadInputException("'%s' is not a known command".formatted(input));
-        }
+        return switch (elements.getCommand()) {
+            case "bye" -> new ExitCommand(elements);
+            case "list" -> new ListCommand(elements);
+            case "mark" -> new MarkCommand(elements);
+            case "unmark" -> new UnmarkCommand(elements);
+            case "delete" -> new DeleteCommand(elements);
+            case "find" -> new FindCommand(elements);
+            case "todo", "deadline", "event" -> new AddCommand(elements);
+            default -> throw new BadInputException("'%s' is not a known command".formatted(input));
+        };
     }
 }

--- a/src/main/java/mittens/parser/RawCommandElements.java
+++ b/src/main/java/mittens/parser/RawCommandElements.java
@@ -1,0 +1,228 @@
+package mittens.parser;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+public class RawCommandElements {
+    private final String command;
+    private final String argument;
+    private final Map<String, String> flagMap;
+
+    /**
+     * Initializes the String elements of the command, including the
+     * command name, argument, and a map of flags to their values.
+     * Command and flag names are converted to lowercase.
+     *
+     * @param input The user input string
+     */
+    public RawCommandElements(String input) {
+        this.flagMap = new HashMap<>();
+
+        String[] parts = input.split("\\s+", 2);
+        this.command = parts[0].toLowerCase();
+
+        if (parts.length > 1) {
+            String[] elements = parts[1].split("\\s+\\\\");
+            this.argument = elements[0];
+
+            for (int i = 1; i < elements.length; i++) {
+                String[] flag = elements[i].split("\\s+", 2);
+                this.flagMap.put(flag[0].toLowerCase(), flag[1]);
+            }
+        } else {
+            this.argument = null;
+        }
+    }
+
+    public String getCommand() {
+        return this.command;
+    }
+
+    public String getArgument() {
+        return this.argument;
+    }
+
+    /**
+     * Returns the argument as an integer.
+     *
+     * @return The integer value of the argument if it exists, otherwise null
+     * @throws BadInputException If the argument is not an integer
+     */
+    public Integer getArgumentAsInteger() throws BadInputException {
+        if (this.argument == null) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(this.argument);
+        } catch (NumberFormatException e) {
+            throw new BadInputException("Argument must be an integer");
+        }
+    }
+
+    /**
+     * Requires the argument to exist and returns it as string.
+     *
+     * @return The string value of the argument
+     * @throws BadInputException If the argument is missing
+     */
+    public String getArgumentOrThrow() throws BadInputException {
+        String value = getArgument();
+        if (value == null) {
+            throw new BadInputException("Command must include an argument");
+        }
+        return value;
+    }
+
+    /**
+     * Requires the argument to exist and returns it as integer.
+     *
+     * @return The string value of the argument
+     * @throws BadInputException If the argument is missing or is not an integer
+     */
+    public int getArgumentAsIntegerOrThrow() throws BadInputException {
+        Integer value = getArgumentAsInteger();
+        if (value == null) {
+            throw new BadInputException("Command must include an argument");
+        }
+        return value;
+    }
+
+    /**
+     * Returns the value of the flag as string.
+     *
+     * @param flag The flag name in lowercase
+     * @return The string value of the flag if it exists, otherwise null
+     */
+    public String getFlag(String flag) {
+        return this.flagMap.get(flag);
+    }
+
+    /**
+     * Returns the value of the flag as integer.
+     *
+     * @param flag The flag name in lowercase
+     * @return The integer value of the flag if it exists, otherwise null
+     * @throws BadInputException If the value is not an integer
+     */
+    public Integer getFlagAsInteger(String flag) throws BadInputException {
+        String value = this.flagMap.get(flag);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new BadInputException("Flag '%s' must be an integer".formatted(flag));
+        }
+    }
+
+    /**
+     * Returns the value of the flag as date.
+     *
+     * @param flag The flag name in lowercase
+     * @return The date value of the flag if it exists, otherwise null
+     * @throws BadInputException If the value is not a date in the format 'yyyy-mm-dd'
+     */
+    public LocalDate getFlagAsDate(String flag) throws BadInputException {
+        String value = this.flagMap.get(flag);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(value);
+        } catch (DateTimeParseException e) {
+            throw new BadInputException("Flag '%s' must be a date in the format 'yyyy-mm-dd'".formatted(flag));
+        }
+    }
+
+    /**
+     * Requires the flag to exist and returns its value as string.
+     *
+     * @param flag The flag name in lowercase
+     * @return The string value of the flag
+     * @throws BadInputException If the flag is missing
+     */
+    public String getFlagOrThrow(String flag) throws BadInputException {
+        String value = getFlag(flag);
+        if (value == null) {
+            throw new BadInputException("Command must include flag '%s'".formatted(flag));
+        }
+        return value;
+    }
+
+    /**
+     * Requires the flag to exist and returns its value as integer.
+     *
+     * @param flag The flag name in lowercase
+     * @return The integer value of the flag
+     * @throws BadInputException If the flag is missing or is not an integer
+     */
+    public int getFlagAsIntegerOrThrow(String flag) throws BadInputException {
+        Integer value = getFlagAsInteger(flag);
+        if (value == null) {
+            throw new BadInputException("Command must include flag '%s'".formatted(flag));
+        }
+        return value;
+    }
+
+    /**
+     * Requires the flag to exist and returns its value as date.
+     *
+     * @param flag The flag name in lowercase
+     * @return The date value of the flag
+     * @throws BadInputException If the flag is missing or is not a date in the format 'yyyy-mm-dd'
+     */
+    public LocalDate getFlagAsDateOrThrow(String flag) throws BadInputException {
+        LocalDate value = getFlagAsDate(flag);
+        if (value == null) {
+            throw new BadInputException("Command must include flag '%s'".formatted(flag));
+        }
+        return value;
+    }
+
+    /**
+     * Checks if the command has all the mandatory flags.
+     *
+     * @param flags The flag strings to check for, in lowercase
+     * @throws BadInputException If any of the flags are missing
+     */
+    public void checkIfHasAllFlags(String... flags) throws BadInputException {
+        List<String> missingFlags = new ArrayList<>();
+        for (String flag : flags) {
+            if (!this.flagMap.containsKey(flag)) {
+                missingFlags.add(flag);
+            }
+        }
+
+        if (!missingFlags.isEmpty()) {
+            throw new BadInputException("Command must include the following flags: %s"
+                    .formatted(String.join(", ", missingFlags)));
+        }
+    }
+
+    /**
+     * Checks if all flags for this command are part of the given set.
+     *
+     * @param flags The flag strings to check for, in lowercase
+     * @throws BadInputException If any of the flags are outside the set
+     */
+    public void checkIfAllFlagsIn(String... flags) throws BadInputException {
+        List<String> invalidFlags = new ArrayList<>();
+        HashSet<String> flagSet = new HashSet<>(List.of(flags));
+        for (String flag : this.flagMap.keySet()) {
+            if (!flagSet.contains(flag)) {
+                invalidFlags.add(flag);
+            }
+        }
+
+        if (!invalidFlags.isEmpty()) {
+            throw new BadInputException("Found unknown flags: %s"
+                    .formatted(String.join(", ", invalidFlags)));
+        }
+    }
+}


### PR DESCRIPTION
Refactor `CommandParser` into separate layers of abstraction, including:
- Creating `RawCommandElements` to represent the elements composing a command string (command name, argument, and flags)
- Moving parsing methods of each command type into their respective classes